### PR TITLE
ci: publishing to NPM added

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,12 +85,13 @@ jobs:
           access: public
           registry: https://registry.npmjs.org/
 
-      - name: Github package publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          access: public
-          registry: https://npm.pkg.github.com
+      # Can not publish to github package registry since Github org has not been migrated to verified.inc yet.
+      # - name: Github package publish
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     access: public
+      #     registry: https://npm.pkg.github.com
 
       # ref: https://github.com/marketplace/actions/delete-tag-and-release
       - name: Delete the v tag

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,20 +77,20 @@ jobs:
         run: |
           ./createTypedocs.sh
           
-      # # ref: https://github.com/marketplace/actions/npm-publish
-      # - name: NPM package publish
-      #   uses: JS-DevTools/npm-publish@v1
-      #   with:
-      #     token: ${{ secrets.NPM_TOKEN }}
-      #     access: public
-      #     registry: https://registry.npmjs.org/
+      # ref: https://github.com/marketplace/actions/npm-publish
+      - name: NPM package publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public
+          registry: https://registry.npmjs.org/
 
-      # - name: Github package publish
-      #   uses: JS-DevTools/npm-publish@v1
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     access: public
-      #     registry: https://npm.pkg.github.com
+      - name: Github package publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          access: public
+          registry: https://npm.pkg.github.com
 
       # ref: https://github.com/marketplace/actions/delete-tag-and-release
       - name: Delete the v tag

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Schema SDK
-SDK for Unum ID credential scheme handling, e.g. definitions and validation.
+SDK for Verified.Inc credential scheme handling, e.g. definitions and validation.
 
 ## JSON-LD Schemas
 Json-LD Schemas are integral as a description format for arbitrary data types. We use it to enable enriched UX around credentials, i.e. in the Wallet's Presentation Request for describing the credentials being requested. They are written in W3C [RDFS](https://www.w3.org/TR/rdf-schema/) syntax. Following [schema.org](https://github.com/schemaorg/schemaorg/)'s lead. 

--- a/build/package.json
+++ b/build/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@unumid/schema-sdk",
+  "name": "@verifiedinc/schema-sdk",
   "version": "0.15.0",
   "description": "SDK for Unum ID credential scheme handling, e.g. definitions and validation.",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@unumid/schema-sdk",
+  "name": "@verifiedinc/schema-sdk",
   "version": "0.15.0",
   "description": "SDK for Unum ID credential scheme handling, e.g. definitions and validation.",
   "main": "build/index.js",


### PR DESCRIPTION
## Summary
Adding CI publishing to NPM verified.inc org added. Also, updated package name to be @verifiedinc/schema-sdk.

## Changes
- feat: ci auto publish sdk to npm
- fix: package name updated
- fix: rm github package publishing.
- fix: name in readme

## Testing
- tested with tags v0.15.1-3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects